### PR TITLE
ckd.sh: fix infinit loop when searching relative path

### DIFF
--- a/ckd.sh
+++ b/ckd.sh
@@ -57,6 +57,11 @@ function get_relative_path()
         # no match, means that candidate common part is not correct
         # go up one level (reduce common part)
         common_part="$(dirname $common_part)"
+
+        if [[ "$common_part" == "." ]]; then
+            break
+        fi
+
         # and record that we went back, with correct / handling
         if [[ -z $result ]]; then
             result=".."


### PR DESCRIPTION
If we pass file path like below, we can't change $common_part anymore. The loop will not exit for ever:

    /path_to/ckd.sh -f drivers/edac/zynqmp_edac.c -s .

, which the relative path is already correct for searching. Hence, we need to exit the loop.