### PR TITLE
ckd.sh: don't exit when no Kconfig found

### DIFF
--- a/ckd.sh
+++ b/ckd.sh
@@ -111,9 +111,13 @@ function get_kconf_files()
     kconfig=$rel_path/Kconfig
     filename=$(basename $1)
 
-    if [[ ! -f $makefile ]] || [[ ! -f $kconfig ]]; then
-        echo "$makefile or $kconfig not exist"
+    if [[ ! -f $makefile ]]; then
+        echo "$makefile not exist"
         exit 20
+    fi
+
+    if [[ ! -f $kconfig ]]; then
+        echo "NOTICE: $kconfig not exist"
     fi
 
     [[ $verbose -eq 1 ]] && echo $makefile

--- a/runtest.sh
+++ b/runtest.sh
@@ -14,6 +14,7 @@ test_cases[0]="drivers/gpu/drm/i915/i915_gem_evict.c"
 test_cases[1]="drivers/gpu/drm/i915/i915_hwmon.c"
 test_cases[2]="drivers/edac/zynqmp_edac.c"
 test_cases[3]="drivers/usb/core/port.c"
+test_cases[4]="kernel/relay.c"
 
 source_tree=$1
 


### PR DESCRIPTION
Some source files are built with CONFIG_XXX directly. No the related kconfig file, then we don't need to search the dependency.